### PR TITLE
BestTree class that aims to calculate the best possible tree, as well as the needed predict method

### DIFF
--- a/CHAID/best_tree.py
+++ b/CHAID/best_tree.py
@@ -1,0 +1,60 @@
+from sklearn.model_selection import train_test_split
+from sklearn.metrics import accuracy_score
+import pandas as pd
+import numpy as np
+from hyperopt import hp, tpe, fmin
+from tqdm import tqdm
+import pickle
+from .tree import Tree
+
+
+class BestTree(object):
+    def __init__(self, ind, dep, n=100, split_titles=None, variable_types=None):
+        """
+        Finds the best tree, while preventing overfitting
+
+        * only supports categorical dependent var
+        """
+        self.pbar = tqdm(total=n, desc="Finding best CHAID params")
+        self.ind = ind
+        self.dep = dep
+        self.n = n
+        self.split_titles = split_titles
+        self.variable_types = variable_types
+
+    def calculate(self):
+        space = [
+            ('Alpha Merge', hp.normal('alpha_merge', 0.3, 0.2)),
+            ('Max Depth', hp.randint('max_depth', 10)),
+            ('Min Parent Node Size', hp.randint('min_parent_node_size', 100)),
+            ('Min Child Node Size', hp.randint('min_child_node_size', 100)),
+        ]
+
+        best = fmin(fn=lambda config: 1 - self.train(self.ind, self.dep, self.n, self.split_titles, self.variable_types, config),
+            space=space,
+            algo=tpe.suggest,
+            max_evals=self.n)
+
+        self.pbar.close()
+
+        return best
+
+    def train(self, ind, dep, n, split_titles, variable_types, conf):
+        alpha_merge, max_depth, min_parent_node_size, min_child_node_size = conf
+        accuracies = []
+        for _ in range(0, n):
+            X_train, X_test, Y_train, Y_test = train_test_split(ind, dep)
+            tree = Tree.from_numpy(X_train, Y_train, alpha_merge=alpha_merge[1],
+                min_child_node_size=min_child_node_size[1], max_depth=max_depth[1],
+                variable_types=variable_types, split_titles=split_titles,
+                min_parent_node_size=min_parent_node_size[1],
+            )
+            predictions = tree.predict(X_test)
+            if predictions is None or np.isnan(predictions).any():
+                continue
+            acc = accuracy_score(Y_test, predictions)
+            accuracies.append(acc)
+        self.pbar.update()
+        if len(accuracies) == 0:
+            return 0
+        return sum(accuracies) / float(len(accuracies))

--- a/CHAID/best_tree.py
+++ b/CHAID/best_tree.py
@@ -4,7 +4,6 @@ import pandas as pd
 import numpy as np
 from hyperopt import hp, tpe, fmin
 from tqdm import tqdm
-import pickle
 from .tree import Tree
 
 


### PR DESCRIPTION
This PR contains a class called BestTree, that takes in predictors and target and uses hyperopts to find the best set of params using train/test split for the data.

It is used as follows:

``` python
>>> best_config = BestTree(df[ind_vars].values, df[dep_var].values, 30, split_titles=ind_vars).calculate()
{'alpha_merge': 0.42586970334320423, 'max_depth': 6, 'min_child_node_size': 32, 'min_parent_node_size': 31}
>>> # use this to create a new tree
>>> tree = Tree.from_pandas_df(data, types, nspace.dependent_variable[0],
                                   **best_config)
```

This involved creating the function `.predict()`, which applies the tree's model to a data set. E.g.:

``` python
>>> tree.predict(data[list(types.keys())].values[: 10, :])
array([1., 0., 1., 0., 1., 0., 1., 0., 1., 0.])
```

It comes with a way of running it from the command line.

Run with standard params:
``` bash
➜ python -m CHAID tests/data/titanic.csv survived sex pclass embarked
([], {0: 809.0, 1: 500.0}, (sex, p=1.47145310169e-81, score=365.886947811, groups=[['female'], ['male']]), dof=1))
|-- (['female'], {0: 127.0, 1: 339.0}, (pclass, p=7.50718706569e-26, score=115.702703161, groups=[[1], [2], [3]]), dof=2))
|   |-- ([1], {0: 5.0, 1: 139.0}, <Invalid Chaid Split> - the max depth has been reached)
|   |-- ([2], {0: 12.0, 1: 94.0}, <Invalid Chaid Split> - the max depth has been reached)
|   +-- ([3], {0: 110.0, 1: 106.0}, <Invalid Chaid Split> - the max depth has been reached)
+-- (['male'], {0: 682.0, 1: 161.0}, (pclass, p=9.19686249011e-09, score=33.0040176609, groups=[[1], [2, 3]]), dof=1))
    |-- ([1], {0: 118.0, 1: 61.0}, <Invalid Chaid Split> - the max depth has been reached)
    +-- ([2, 3], {0: 564.0, 1: 100.0}, <Invalid Chaid Split> - the max depth has been reached)

('Accuracy: ', 0.7830404889228418)
```

Find better tree:
``` bash
➜ python -m CHAID tests/data/titanic.csv survived sex pclass embarked --find-best --n 100
Finding best CHAID params: 100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 100/100 [03:43<00:00,  2.26s/it]
('Best config: ', {'min_parent_node_size': 53, 'alpha_merge': 0.1784422075047269, 'max_depth': 6, 'min_child_node_size': 23})
([], {0: 809.0, 1: 500.0}, (sex, p=1.47145310169e-81, score=365.886947811, groups=[['female'], ['male']]), dof=1))
|-- (['female'], {0: 127.0, 1: 339.0}, (pclass, p=7.50718706569e-26, score=115.702703161, groups=[[1], [2], [3]]), dof=2))
|   |-- ([1], {0: 5.0, 1: 139.0}, <Invalid Chaid Split> - the node only contains single category respondents)
|   |-- ([2], {0: 12.0, 1: 94.0}, <Invalid Chaid Split> - the node only contains single category respondents)
|   +-- ([3], {0: 110.0, 1: 106.0}, (embarked, p=0.000638052386506, score=11.6615476457, groups=[['C', 'Q'], ['S']]), dof=1))
|       |-- (['C', 'Q'], {0: 32.0, 1: 55.0}, <Invalid Chaid Split> - the node only contains single category respondents)
|       +-- (['S'], {0: 78.0, 1: 51.0}, <Invalid Chaid Split> - the node only contains single category respondents)
+-- (['male'], {0: 682.0, 1: 161.0}, (pclass, p=9.19686249011e-09, score=33.0040176609, groups=[[1], [2, 3]]), dof=1))
    |-- ([1], {0: 118.0, 1: 61.0}, <Invalid Chaid Split> - the node only contains single category respondents)
    +-- ([2, 3], {0: 564.0, 1: 100.0}, (embarked, p=0.0265545221538, score=4.91954418577, groups=[['C'], ['Q', 'S']]), dof=1))
        |-- (['C'], {0: 67.0, 1: 20.0}, <Invalid Chaid Split> - the node only contains single category respondents)
        +-- (['Q', 'S'], {0: 497.0, 1: 80.0}, <Invalid Chaid Split> - the node only contains single category respondents)

('Accuracy: ', 0.80061115355233)
```
