### PR TITLE
Refactor Graph to avoid cross-platform issues

### DIFF
--- a/CHAID/graph.py
+++ b/CHAID/graph.py
@@ -45,7 +45,7 @@ class Graph(object):
             )
             for node in self.tree:
                 image = self.bar_chart(node)
-                g.node(str(node.node_id), attributes={"image": image})
+                g.node(str(node.node_id), image=image)
                 if node.parent is not None:
                     edge_label = "   ( {})".format(', '.join(node.choices))
                     g.edge(str(node.parent), str(node.node_id), label=edge_label)

--- a/CHAID/graph.py
+++ b/CHAID/graph.py
@@ -24,18 +24,15 @@ except ImportError:
 
 FIG_BASE = {
     "layout": {
-        "margin": {"t": 50},
-        "annotations": [
-            {"font": {"size": 18}, "showarrow": False, "text": "", "x": 0.5, "y": 0.5},
-            {"y": {"domain": [0, 0.2]}},
-        ],
+        "margin_t": 50,
+        "annotations": [{"font_size": 18, "x": 0.5, "y": 0.5}, {"y": [0, 0.2]}],
     },
 }
 FIG_BASE_DATA = {
     "domain": {"x": [0, 1], "y": [0.4, 1.0]},
     "hole": 0.4,
     "type": "pie",
-    "marker": {"colors": cl.scales["5"]["qual"]["Set1"]},
+    "marker_colors": cl.scales["5"]["qual"]["Set1"],
 }
 TABLE_HEADER = ["<i>p</i>", "score", "splitting on"]
 TABLE_CONFIG = {

--- a/CHAID/graph.py
+++ b/CHAID/graph.py
@@ -91,16 +91,16 @@ class Graph(object):
         score = None if node.score is None else format(node.score, ".2f")
         return go.Table(
             domain={"x": [0.3, 0.7], "y": [0, 0.37]},
-            header={"height": 0, "line": {"color": "white"}, "fill": {"color": "white"}},
+            header={"fill_color": "#FFF"},
             cells={
                 "values": [
                     ["<i>p</i>", "score", "splitting on"],
                     [p, score, node.split.column],
                 ],
-                "line": {"color": "#FFF"},
-                "align": ["left"] * 5,
-                "font": {"color": ["rgb(40, 40, 40)"] * 5, "size": 12},
+                "line_color": "#FFF",
+                "align": "left",
+                "font_color": "#282828",
                 "height": 27,
-                "fill": {"color": ["rgb(235, 193, 238)", "rgba(228, 222, 249, 0.65)"]},
+                "fill_color": ["#EBC1EE", "#EDEAFB"],
             },
         )

--- a/CHAID/graph.py
+++ b/CHAID/graph.py
@@ -47,8 +47,8 @@ class Graph(object):
                 image = self.bar_chart(node)
                 g.node(str(node.node_id), image=image)
                 if node.parent is not None:
-                    edge_label = "   ( {})".format(', '.join(node.choices))
-                    g.edge(str(node.parent), str(node.node_id), label=edge_label)
+                    edge_label = "   ({})   \n ".format(', '.join(node.choices))
+                    g.edge(str(node.parent), str(node.node_id), xlabel=edge_label)
             g.render(path, view=view)
 
     def bar_chart(self, node):

--- a/CHAID/graph.py
+++ b/CHAID/graph.py
@@ -8,12 +8,12 @@ from graphviz import Digraph
 
 try:
     # Python 3.2 and newer
-    from tempfile import mkstemp, TemporaryDirectory
+    from tempfile import TemporaryDirectory
 except ImportError:
     # minimal backport of TemporaryDirectory for Python 2.7, sufficient
     # for use with this module.
     import shutil
-    from tempfile import mkdtemp, mkstemp
+    from tempfile import mkdtemp
     class TemporaryDirectory(object):
         def __init__(self):
             self.name = mkdtemp()

--- a/CHAID/graph.py
+++ b/CHAID/graph.py
@@ -22,6 +22,34 @@ except ImportError:
         def __exit__(self, *args):
             shutil.rmtree(self.name, ignore_errors=True)
 
+FIG_BASE = {
+    "layout": {
+        "margin": {"t": 50},
+        "annotations": [
+            {"font": {"size": 18}, "showarrow": False, "text": "", "x": 0.5, "y": 0.5},
+            {"y": {"domain": [0, 0.2]}},
+        ],
+    },
+}
+FIG_BASE_DATA = {
+    "domain": {"x": [0, 1], "y": [0.4, 1.0]},
+    "hole": 0.4,
+    "type": "pie",
+    "marker": {"colors": cl.scales["5"]["qual"]["Set1"]},
+}
+TABLE_HEADER = ["<i>p</i>", "score", "splitting on"]
+TABLE_CONFIG = {
+    "domain": {"x": [0.3, 0.7], "y": [0, 0.37]},
+    "header": {"fill_color": "#FFF"},
+}
+TABLE_CELLS_CONFIG = {
+    "line_color": "#FFF",
+    "align": "left",
+    "font_color": "#282828",
+    "height": 27,
+    "fill_color": ["#EBC1EE", "#EDEAFB"],
+}
+
 class Graph(object):
     """
     Visualisation of the tree
@@ -52,32 +80,17 @@ class Graph(object):
             g.render(path, view=view)
 
     def bar_chart(self, node):
-        fig = {
-            "data": [
-                {
-                    "values": list(node.members.values()),
-                    "labels": list(node.members),
-                    "domain": {"x": [0, 1], "y": [0.4, 1.0]},
-                    "hole": 0.4,
-                    "type": "pie",
-                    "showlegend": node.node_id == 0,
-                    "marker": {"colors": cl.scales["5"]["qual"]["Set1"]},
-                }
+        fig = dict(
+            data=[
+                dict(
+                    values=list(node.members.values()),
+                    labels=list(node.members),
+                    showlegend=(node.node_id == 0),
+                    **FIG_BASE_DATA
+                )
             ],
-            "layout": {
-                "margin": {"t": 50},
-                "annotations": [
-                    {
-                        "font": {"size": 18},
-                        "showarrow": False,
-                        "text": "",
-                        "x": 0.5,
-                        "y": 0.5,
-                    },
-                    {"y": {"domain": [0, 0.2]}},
-                ],
-            },
-        }
+            **FIG_BASE
+        )
 
         if not node.is_terminal:
             fig["data"].append(self._table(node))
@@ -89,18 +102,8 @@ class Graph(object):
     def _table(self, node):
         p = None if node.p is None else format(node.p, ".5f")
         score = None if node.score is None else format(node.score, ".2f")
+        values = [p, score, node.split.column]
         return go.Table(
-            domain={"x": [0.3, 0.7], "y": [0, 0.37]},
-            header={"fill_color": "#FFF"},
-            cells={
-                "values": [
-                    ["<i>p</i>", "score", "splitting on"],
-                    [p, score, node.split.column],
-                ],
-                "line_color": "#FFF",
-                "align": "left",
-                "font_color": "#282828",
-                "height": 27,
-                "fill_color": ["#EBC1EE", "#EDEAFB"],
-            },
+            cells=dict(values=[TABLE_HEADER, values], **TABLE_CELLS_CONFIG),
+            **TABLE_CONFIG
         )

--- a/CHAID/graph.py
+++ b/CHAID/graph.py
@@ -1,10 +1,26 @@
-from graphviz import Digraph
-import datetime
-import time
+import os
+from datetime import datetime
+
 import plotly.graph_objs as go
 import plotly.io as pio
 import colorlover as cl
-import os
+from graphviz import Digraph
+
+try:
+    # Python 3.2 and newer
+    from tempfile import mkstemp, TemporaryDirectory
+except ImportError:
+    # minimal backport of TemporaryDirectory for Python 2.7, sufficient
+    # for use with this module.
+    import shutil
+    from tempfile import mkdtemp, mkstemp
+    class TemporaryDirectory(object):
+        def __init__(self):
+            self.name = mkdtemp()
+        def __enter__(self):
+            return self.name
+        def __exit__(self, *args):
+            shutil.rmtree(self.name, ignore_errors=True)
 
 class Graph(object):
     """
@@ -17,77 +33,71 @@ class Graph(object):
 
     def __init__(self, tree):
         self.tree = tree
-        self.files = []
 
     def render(self, path, view):
-        g = Digraph(format='png')
-        for node in self.tree:
-            m, p, score = node.members, None, None
-            if node.p is not None and node.score is not None:
-                p = str(round(node.p, 5))
-                score = str(round(node.score, 2))
-            g.node(str(node.node_id), '', {'shape': 'plaintext', 'image': self.bar_chart(
-                m, node.is_terminal, node.node_id == 0, p, score, node.split.column), 'labelloc': 'b'})
-            if node.parent is not None:
-                edge_label = '   ( ' + ', '.join(node.choices) + ')'
-                g.edge(str(node.parent), str(node.node_id), label=edge_label)
-        g.graph_attr['splines'] = 'ortho'
-        g.render(
-            'trees/' + datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S") + '.gv'
-            if path is None
-            else path,
-            view=view
-        )
-        self.remove_tmp_files()
+        if path is None:
+            path = os.path.join("trees", "{:%Y-%m-%d %H:%M:%S}.gv".format(datetime.now()))
+        with TemporaryDirectory() as self.tempdir:
+            g = Digraph(
+                format="png",
+                graph_attr={"splines": "ortho"},
+                node_attr={"shape": "plaintext", "labelloc": "b"},
+            )
+            for node in self.tree:
+                image = self.bar_chart(node)
+                g.node(str(node.node_id), attributes={"image": image})
+                if node.parent is not None:
+                    edge_label = "   ( {})".format(', '.join(node.choices))
+                    g.edge(str(node.parent), str(node.node_id), label=edge_label)
+            g.render(path, view=view)
 
-    def bar_chart(self, members, is_terminal, is_root, p, score, split):
+    def bar_chart(self, node):
         fig = {
             "data": [
-              {
-                  "values": [v for v in members.values()],
-                  "labels": [k for k in members.keys()],
-                  "domain": {"x": [0, 1], "y":[0.4, 1.0]},
-                  "hole": .4,
-                  "type": "pie",
-                  'showlegend': True if is_root else False,
-                  'marker': {'colors': cl.scales['5']['qual']['Set1']}
-              }],
+                {
+                    "values": list(node.members.values()),
+                    "labels": list(node.members),
+                    "domain": {"x": [0, 1], "y": [0.4, 1.0]},
+                    "hole": 0.4,
+                    "type": "pie",
+                    "showlegend": node.node_id == 0,
+                    "marker": {"colors": cl.scales["5"]["qual"]["Set1"]},
+                }
+            ],
             "layout": {
-                "margin": dict(t=50),
+                "margin": {"t": 50},
                 "annotations": [
                     {
-                        "y": {'domain': [0, 0.2]},
-                        "font": {
-                            "size": 18
-                        },
+                        "font": {"size": 18},
                         "showarrow": False,
-                        "text": '',
+                        "text": "",
                         "x": 0.5,
-                        "y": 0.5
+                        "y": 0.5,
                     },
-                    {
-                        "y": {'domain': [0, 0.2]},
-                    }
-                ]
-            }
+                    {"y": {"domain": [0, 0.2]}},
+                ],
+            },
         }
-        if is_terminal is False: self.append_table(fig, [p, score, split])
-        file = '/tmp/' + ("%.20f" % time.time()).replace('.', '') + '.png'
-        pio.write_image(fig, file=file, format='png')
-        self.files.append(file)
-        return file
 
-    def append_table(self, fig, table_scores):
-        table = go.Table(
-            domain=dict(x=[0.3, 0.7], y=[0, 0.37]),
-            header=dict(height=0, line = dict(color = 'white'),
-                        fill = dict(color = 'white')),
-            cells=dict(values=[['<i>p</i>', 'score', 'splitting on'], table_scores],
-                       line=dict(color='#FFF'), align=['left'] * 5,
-                       font=dict(color=['rgb(40, 40, 40)'] * 5, size=12), height=27,
-                       fill=dict(color=['rgb(235, 193, 238)', 'rgba(228, 222, 249, 0.65)']))
+        if not node.is_terminal:
+            fig["data"].append(self._table(node))
+
+        filename = mkstemp(suffix=".png", dir=self.tempdir)[1]
+        pio.write_image(fig, file=filename, format="png")
+        return filename
+
+    def _table(self, node):
+        p = None if node.p is None else format(node.p, ".5f")
+        score = None if node.score is None else format(node.score, ".2f")
+        return go.Table(
+            domain={"x": [0.3, 0.7], "y": [0, 0.37]},
+            header={"height": 0, "line": {"color": "white"}, "fill": {"color": "white"}},
+            cells={
+                "values": [["<i>p</i>", "score", "splitting on"], [p, score, node.split.column],
+                "line": {"color": "#FFF"},
+                "align": ["left"] * 5,
+                "font": {"color": ["rgb(40, 40, 40)"] * 5, "size": 12,},
+                "height": 27,
+                "fill": {"color": ["rgb(235, 193, 238)", "rgba(228, 222, 249, 0.65)"]},
+            },
         )
-        fig['data'].append(table)
-
-    def remove_tmp_files(self):
-        [os.remove(file) for file in self.files]

--- a/CHAID/graph.py
+++ b/CHAID/graph.py
@@ -93,10 +93,13 @@ class Graph(object):
             domain={"x": [0.3, 0.7], "y": [0, 0.37]},
             header={"height": 0, "line": {"color": "white"}, "fill": {"color": "white"}},
             cells={
-                "values": [["<i>p</i>", "score", "splitting on"], [p, score, node.split.column],
+                "values": [
+                    ["<i>p</i>", "score", "splitting on"],
+                    [p, score, node.split.column],
+                ],
                 "line": {"color": "#FFF"},
                 "align": ["left"] * 5,
-                "font": {"color": ["rgb(40, 40, 40)"] * 5, "size": 12,},
+                "font": {"color": ["rgb(40, 40, 40)"] * 5, "size": 12},
                 "height": 27,
                 "fill": {"color": ["rgb(235, 193, 238)", "rgba(228, 222, 249, 0.65)"]},
             },

--- a/CHAID/graph.py
+++ b/CHAID/graph.py
@@ -82,7 +82,7 @@ class Graph(object):
         if not node.is_terminal:
             fig["data"].append(self._table(node))
 
-        filename = mkstemp(suffix=".png", dir=self.tempdir)[1]
+        filename = os.path.join(self.tempdir, "node-{}.png".format(node.node_id))
         pio.write_image(fig, file=filename, format="png")
         return filename
 

--- a/CHAID/graph.py
+++ b/CHAID/graph.py
@@ -72,7 +72,7 @@ class Graph(object):
                 image = self.bar_chart(node)
                 g.node(str(node.node_id), image=image)
                 if node.parent is not None:
-                    edge_label = "   ({})   \n ".format(', '.join(node.choices))
+                    edge_label = "     ({})     \n ".format(', '.join(node.choices))
                     g.edge(str(node.parent), str(node.node_id), xlabel=edge_label)
             g.render(path, view=view)
 

--- a/CHAID/graph.py
+++ b/CHAID/graph.py
@@ -72,7 +72,7 @@ class Graph(object):
                 image = self.bar_chart(node)
                 g.node(str(node.node_id), image=image)
                 if node.parent is not None:
-                    edge_label = "     ({})     \n ".format(', '.join(node.choices))
+                    edge_label = "     ({})     \n ".format(', '.join(map(str, node.choices)))
                     g.edge(str(node.parent), str(node.node_id), xlabel=edge_label)
             g.render(path, view=view)
 


### PR DESCRIPTION
This uses

- `tempfile.TemporaryDirectory()` to handle cleaning up temporary files for the images. This isn't available in Python 2.7 but a simple backport is included (the standard-library version goes a little further in cleaning up still, should not be needed here).
- `tempfile.mkstemp()` to generate image filenames, those are guaranteed to be unique without needing to generate filenames based on the current timestamp.
- I cleaned up the code to be Flake-8 clean and better factored.

This should fix #97.

Caveat: I haven't actually *run* this code, it's pure dead reconning and linters. :-)