### PR TITLE
Py2 compat: add conditional dep

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,19 @@ setup(
     ],
     keywords='CHAID pandas numpy scipy statistics statistical analysis',
     packages=find_packages(exclude=['contrib', 'docs', 'tests']),
-    install_requires=['cython', 'numpy', 'pandas', 'treelib', 'pytest', 'scipy', 'savReaderWriter', 'graphviz', 'plotly', 'colorlover'],
+    install_requires=[
+        'cython',
+        'numpy',
+        'pandas',
+        'treelib',
+        'pytest',
+        'scipy',
+        'savReaderWriter',
+        'graphviz',
+        'plotly',
+        'colorlover',
+        'enum34; python_version == "2.7"'
+    ],
     extras_require={
         'test': ['codecov', 'tox', 'tox-pyenv', 'detox', 'pytest', 'pytest-cov'],
     }


### PR DESCRIPTION
Python 2.7 doesn't have the enum module, but the enum34 backport suffices here. Include it only when Python 2.7 is used.

Fixes #101