### PR TITLE
Fix errors due to numpy deprecation; split required packages further; update specs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,66 +3,153 @@ workflows:
   version: 2
   test:
     jobs:
+      - test-3.11
+      - test-3.10
+      - test-3.9
       - test-3.8
       - test-3.7
       - test-3.6
 jobs:
-  test-3.8: &test-template
+  test-3.11: &test-template
     docker:
-      - image: circleci/python:3.8.1-buster
+      - image: cimg/python:3.11
     working_directory: ~/repo
     steps:
       - checkout
       - restore_cache:
           keys:
-          - v1-dependencies-{{ checksum "setup.py" }}
-          - v1-dependencies-
+          - v1-3.11-dependencies-{{ checksum "setup.py" }}
+          - v1-3.11-dependencies-
       - run:
           name: Install dependencies
           command: |
             sudo apt-get update
-            sudo apt-get install graphviz nodejs npm libnss3 libgtk-3-0 libasound2
-            sudo npm install yarn -g
-            sudo yarn global add electron@6.1.4 orca
+            sudo apt-get install graphviz nodejs npm libnss3 libgtk-3-0 libasound2 libgtk2.0-0 libgconf-2-4 chromium-browser xvfb
+            sudo npm install -g electron@6.1.4 orca
             python3 -m pip install --user --upgrade pip
             python -m venv venv || virtualenv venv
             . venv/bin/activate
-            pip install -e '.[test]'
+            pip install -e '.[test,graph,spss]'
       - save_cache:
           paths:
             - ./venv
-          key: v1-dependencies-{{ checksum "setup.py" }}
+          key: v1-3.11-dependencies-{{ checksum "setup.py" }}
       - run:
           name: Run tests
           command: |
             . venv/bin/activate
-            pytest --cov=CHAID/
-            codecov --token=be8cd1f6-1560-4628-8a34-b557a119894b
-  test-3.7: &test-template
+            pytest --cov
+  test-3.10: &test-template
     docker:
-      - image: circleci/python:3.7.6-buster
+      - image: cimg/python:3.10
     working_directory: ~/repo
     steps:
       - checkout
       - restore_cache:
           keys:
-          - v1-dependencies-{{ checksum "setup.py" }}
-          - v1-dependencies-
+          - v1-3.10-dependencies-{{ checksum "setup.py" }}
+          - v1-3.10-dependencies-
       - run:
           name: Install dependencies
           command: |
             sudo apt-get update
-            sudo apt-get install graphviz nodejs npm libnss3 libgtk-3-0 libasound2
-            sudo npm install yarn -g
-            sudo yarn global add electron@6.1.4 orca
+            sudo apt-get install graphviz nodejs npm libnss3 libgtk-3-0 libasound2 libgtk2.0-0 libgconf-2-4 chromium-browser xvfb
+            sudo npm install -g electron@6.1.4 orca
             python3 -m pip install --user --upgrade pip
             python -m venv venv || virtualenv venv
             . venv/bin/activate
-            pip install -e '.[test]'
+            pip install -e '.[test,graph,spss]'
       - save_cache:
           paths:
             - ./venv
-          key: v1-dependencies-{{ checksum "setup.py" }}
+          key: v1-3.10-dependencies-{{ checksum "setup.py" }}
+      - run:
+          name: Run tests
+          command: |
+            . venv/bin/activate
+            pytest
+  test-3.9: &test-template
+    docker:
+      - image: cimg/python:3.9
+    working_directory: ~/repo
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+          - v1-3.9-dependencies-{{ checksum "setup.py" }}
+          - v1-3.9-dependencies-
+      - run:
+          name: Install dependencies
+          command: |
+            sudo apt-get update
+            sudo apt-get install graphviz nodejs npm libnss3 libgtk-3-0 libasound2 libgtk2.0-0 libgconf-2-4 chromium-browser xvfb
+            sudo npm install -g electron@6.1.4 orca
+            python3 -m pip install --user --upgrade pip
+            python -m venv venv || virtualenv venv
+            . venv/bin/activate
+            pip install -e '.[test,graph,spss]'
+      - save_cache:
+          paths:
+            - ./venv
+          key: v1-3.9-dependencies-{{ checksum "setup.py" }}
+      - run:
+          name: Run tests
+          command: |
+            . venv/bin/activate
+            pytest
+  test-3.8: &test-template
+    docker:
+      - image: cimg/python:3.8
+    working_directory: ~/repo
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+          - v1-3.8-dependencies-{{ checksum "setup.py" }}
+          - v1-3.8-dependencies-
+      - run:
+          name: Install dependencies
+          command: |
+            sudo apt-get update
+            sudo apt-get install graphviz nodejs npm libnss3 libgtk-3-0 libasound2 libgtk2.0-0 libgconf-2-4 chromium-browser xvfb
+            sudo npm install -g electron@6.1.4 orca
+            python3 -m pip install --user --upgrade pip
+            python -m venv venv || virtualenv venv
+            . venv/bin/activate
+            pip install -e '.[test,graph,spss]'
+      - save_cache:
+          paths:
+            - ./venv
+          key: v1-3.8-dependencies-{{ checksum "setup.py" }}
+      - run:
+          name: Run tests
+          command: |
+            . venv/bin/activate
+            pytest
+  test-3.7: &test-template
+    docker:
+      - image: cimg/python:3.7
+    working_directory: ~/repo
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+          - v1-3.7-dependencies-{{ checksum "setup.py" }}
+          - v1-3.7-dependencies-
+      - run:
+          name: Install dependencies
+          command: |
+            sudo apt-get update
+            sudo apt-get install graphviz nodejs npm libnss3 libgtk-3-0 libasound2 libgtk2.0-0 libgconf-2-4 chromium-browser xvfb
+            sudo npm install -g electron@6.1.4 orca
+            python3 -m pip install --user --upgrade pip
+            python -m venv venv || virtualenv venv
+            . venv/bin/activate
+            pip install -e '.[test,graph,spss]'
+      - save_cache:
+          paths:
+            - ./venv
+          key: v1-3.7-dependencies-{{ checksum "setup.py" }}
       - run:
           name: Run tests
           command: |
@@ -70,29 +157,29 @@ jobs:
             pytest
   test-3.6: &test-template
     docker:
-      - image: circleci/python:3.6.9-buster
+      - image: cimg/python:3.6
     working_directory: ~/repo
     steps:
       - checkout
       - restore_cache:
           keys:
-          - v1-dependencies-{{ checksum "setup.py" }}
-          - v1-dependencies-
+          - v1-3.6-dependencies-{{ checksum "setup.py" }}
+          - v1-3.6-dependencies-
       - run:
           name: Install dependencies
           command: |
             sudo apt-get update
-            sudo apt-get install graphviz nodejs npm libnss3 libgtk-3-0 libasound2
+            sudo apt-get install graphviz nodejs npm libnss3 libgtk-3-0 libasound2 libgtk2.0-0 libgconf-2-4 chromium-browser xvfb
             sudo npm install yarn -g
             sudo yarn global add electron@6.1.4 orca
             python3 -m pip install --user --upgrade pip
             python -m venv venv || virtualenv venv
             . venv/bin/activate
-            pip install -e '.[test]'
+            pip install -e '.[test,graph,spss]'
       - save_cache:
           paths:
             - ./venv
-          key: v1-dependencies-{{ checksum "setup.py" }}
+          key: v1-3.6-dependencies-{{ checksum "setup.py" }}
       - run:
           name: Run tests
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,7 +38,8 @@ jobs:
           name: Run tests
           command: |
             . venv/bin/activate
-            pytest --cov
+            pytest --cov=CHAID/
+            codecov --token=be8cd1f6-1560-4628-8a34-b557a119894b
   test-3.10: &test-template
     docker:
       - image: cimg/python:3.10

--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,7 @@ target/
 trees/
 .DS_Store
 tests/graph
+
+# Pipfile
+Pipfile
+Pipfile.lock

--- a/CHAID/__init__.py
+++ b/CHAID/__init__.py
@@ -5,4 +5,4 @@ from .column import NominalColumn, OrdinalColumn, ContinuousColumn
 from .stats import Stats
 from .invalid_split_reason import InvalidSplitReason
 
-__version__ = "5.3.0"
+__version__ = "5.3.1"

--- a/CHAID/column.py
+++ b/CHAID/column.py
@@ -128,7 +128,7 @@ class NominalColumn(Column):
         for new_id, value in enumerate(unique):
             np.place(arr, arr==value, new_id)
             self.metadata[new_id] = value
-        arr = arr.astype(np.float)
+        arr = arr.astype(np.float64)
         np.place(arr, np.isnan(arr), -1)
         self.arr = arr
 

--- a/CHAID/graph.py
+++ b/CHAID/graph.py
@@ -1,20 +1,52 @@
 import os
+import warnings
 from datetime import datetime
 
+# Wrap all the optional imports
 try:
     import plotly.graph_objs as go
     import plotly.io as pio
+    import colorlover as cl
+    from graphviz import Digraph
+    
 except ImportError:
+    warnings.warn('Imports of optional packages needed to generate graphs failed. Please install the optinal package under "graph".')
     go = None
     pio = None
-try:
-    import colorlover as cl
-except ImportError:
     cl = None
-try:
-    from graphviz import Digraph
-except ImportError:
     Digraph = None
+
+    FIG_BASE = {}
+    FIG_BASE_DATA = {}
+    TABLE_HEADER = []
+    TABLE_CONFIG = {}
+    TABLE_CELLS_CONFIG = {}
+
+else:
+    FIG_BASE = {
+        "layout": {
+            "margin_t": 50,
+            "annotations": [{"font_size": 18, "x": 0.5, "y": 0.5}, {"y": [0, 0.2]}],
+        },
+    }
+    FIG_BASE_DATA = {
+        "domain": {"x": [0, 1], "y": [0.4, 1.0]},
+        "hole": 0.4,
+        "type": "pie",
+        "marker_colors": cl.scales["5"]["qual"]["Set1"],
+    }
+    TABLE_HEADER = ["<i>p</i>", "score", "splitting on"]
+    TABLE_CONFIG = {
+        "domain": {"x": [0.3, 0.7], "y": [0, 0.37]},
+        "header": {"fill_color": "#FFF"},
+    }
+    TABLE_CELLS_CONFIG = {
+        "line_color": "#FFF",
+        "align": "left",
+        "font_color": "#282828",
+        "height": 27,
+        "fill_color": ["#EBC1EE", "#EDEAFB"],
+    }    
 
 try:
     # Python 3.2 and newer
@@ -32,30 +64,6 @@ except ImportError:
         def __exit__(self, *args):
             shutil.rmtree(self.name, ignore_errors=True)
 
-FIG_BASE = {
-    "layout": {
-        "margin_t": 50,
-        "annotations": [{"font_size": 18, "x": 0.5, "y": 0.5}, {"y": [0, 0.2]}],
-    },
-}
-FIG_BASE_DATA = {
-    "domain": {"x": [0, 1], "y": [0.4, 1.0]},
-    "hole": 0.4,
-    "type": "pie",
-    "marker_colors": cl.scales["5"]["qual"]["Set1"],
-}
-TABLE_HEADER = ["<i>p</i>", "score", "splitting on"]
-TABLE_CONFIG = {
-    "domain": {"x": [0.3, 0.7], "y": [0, 0.37]},
-    "header": {"fill_color": "#FFF"},
-}
-TABLE_CELLS_CONFIG = {
-    "line_color": "#FFF",
-    "align": "left",
-    "font_color": "#282828",
-    "height": 27,
-    "fill_color": ["#EBC1EE", "#EDEAFB"],
-}
 
 class Graph(object):
     """
@@ -103,7 +111,7 @@ class Graph(object):
             fig["data"].append(self._table(node))
 
         filename = os.path.join(self.tempdir, "node-{}.png".format(node.node_id))
-        pio.write_image(fig, file=filename, format="png")
+        pio.write_image(fig, file=filename, format="png", engine="orca")
         return filename
 
     def _table(self, node):

--- a/CHAID/graph.py
+++ b/CHAID/graph.py
@@ -10,7 +10,7 @@ try:
     from graphviz import Digraph
     
 except ImportError:
-    warnings.warn('Imports of optional packages needed to generate graphs failed. Please install the optinal package under "graph".')
+    warnings.warn(UserWarning('Imports of optional packages needed to generate graphs failed. Please install with the "graph" option.'))
     go = None
     pio = None
     cl = None

--- a/CHAID/graph.py
+++ b/CHAID/graph.py
@@ -1,10 +1,20 @@
 import os
 from datetime import datetime
 
-import plotly.graph_objs as go
-import plotly.io as pio
-import colorlover as cl
-from graphviz import Digraph
+try:
+    import plotly.graph_objs as go
+    import plotly.io as pio
+except ImportError:
+    go = None
+    pio = None
+try:
+    import colorlover as cl
+except ImportError:
+    cl = None
+try:
+    from graphviz import Digraph
+except ImportError:
+    Digraph = None
 
 try:
     # Python 3.2 and newer

--- a/CHAID/split.py
+++ b/CHAID/split.py
@@ -67,6 +67,14 @@ class Split(object):
         return str(self.split_map)
 
     @property
+    def split_groups(self):
+        if not self.valid():
+            return []
+        if all(x is None for x in self.split_map):
+            return self.splits
+        return self.split_map
+
+    @property
     def dof(self):
         return self._dof
 

--- a/CHAID/tree.py
+++ b/CHAID/tree.py
@@ -101,7 +101,7 @@ class Tree(object):
     def build_tree(self):
         """ Build chaid tree """
         self._tree_store = []
-        self.node(np.arange(0, self.data_size, dtype=np.int), self.vectorised_array, self.observed)
+        self.node(np.arange(0, self.data_size, dtype=np.int64), self.vectorised_array, self.observed)
 
     @property
     def tree_store(self):

--- a/README.md
+++ b/README.md
@@ -15,6 +15,21 @@ CHAID is distributed via [pypi](https://pypi.python.org/pypi/CHAID) and can be i
 pip3 install CHAID
 ```
 
+If you need support for graphs, optional packages must be installed together like:
+``` bash
+pip install CHAID[graph]
+```
+
+If you need support to read in a `.sav` file (SPSS), you will also need to install optional packages like:
+``` bash
+pip install CHAID[spss]
+```
+
+To install multiple optional packages, you can use a comma-separated list like:
+``` bash
+pip install CHAID[graph,spss]
+```
+
 Alternatively, you can clone the repository and install via
 ``` bash
 pip install -e path/to/your/checkout

--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,7 @@ setup(
     ],
     extras_require={
         'spss': ['savReaderWriter'],
-        'graph': ['graphviz', 'plotly', 'colorlover'],
+        'graph': ['graphviz', 'plotly', 'colorlover', 'kaleido'],
         'test': ['codecov', 'tox', 'tox-pyenv', 'detox', 'pytest', 'pytest-cov', 'psutil'],
     }
 )

--- a/setup.py
+++ b/setup.py
@@ -55,15 +55,12 @@ setup(
         'numpy',
         'pandas',
         'treelib',
-        'pytest',
         'scipy',
-        'savReaderWriter',
-        'graphviz',
-        'plotly',
-        'colorlover',
         'enum34; python_version == "2.7"'
     ],
     extras_require={
+        'spss': ['savReaderWriter'],
+        'graph': ['graphviz', 'plotly', 'colorlover'],
         'test': ['codecov', 'tox', 'tox-pyenv', 'detox', 'pytest', 'pytest-cov', 'psutil'],
     }
 )

--- a/tests/setup_tests.py
+++ b/tests/setup_tests.py
@@ -1,8 +1,11 @@
 """
 This module provides helper functions for the rest of the testing module
 """
-
-from collections import Iterable
+try:
+    from collections.abc import Iterable
+except ImportError:
+    # Older Python versions
+    from collections import Iterable
 import os
 import sys
 from math import isnan

--- a/tests/test_graph_optional_import.py
+++ b/tests/test_graph_optional_import.py
@@ -1,0 +1,46 @@
+"""
+Testing module for the class Graph
+"""
+import numpy as np
+import pytest
+import builtins, sys
+from importlib import reload
+from unittest.mock import patch
+import os
+
+
+class PackageDiscarder:
+    def __init__(self):
+        self.pkgnames = []
+    def find_spec(self, fullname, path, target=None):
+        if fullname in self.pkgnames:
+            raise ImportError()
+
+
+@pytest.fixture
+def no_graph_packages():
+    modules_to_remove = []
+    for name in sys.modules:
+        if name.startswith('plotly') or name.startswith('graphviz') or name.startswith('CHAID') or name.startswith('setup_tests') or name in ['colorlover', 'graphviz', 'Digraph']:
+            modules_to_remove.append(name)
+    _ = [sys.modules.pop(x) for x in modules_to_remove]
+
+    d = PackageDiscarder()
+    d.pkgnames.extend([
+        'plotly.graph_objs',
+        'plotly.io',
+        'colorlover',
+        'graphviz',
+        'Digraph',
+    ])
+    sys.meta_path.insert(0, d)
+    yield
+    sys.meta_path.remove(d)
+
+
+def test_graph_warns_without_optional_imports(no_graph_packages):
+    """
+    Test that the graph produces an error without the optional imports (mocked)
+    """
+    with pytest.warns(UserWarning, match='Imports of optional packages needed to generate graphs failed. Please install with the "graph" option.'):
+        from setup_tests import CHAID

--- a/tests/test_tree.py
+++ b/tests/test_tree.py
@@ -81,7 +81,8 @@ def test_best_split_unique_values():
     assert list_ordered_equal(ndarr, orig_ndarr), 'Calling chaid should have no side affects for original numpy arrays'
     assert list_ordered_equal(arr, orig_arr), 'Calling chaid should have no side affects for original numpy arrays'
     assert split.column_id == 0, 'Identifies correct column to split on'
-    assert list_unordered_equal(split.split_map, [[1], [2]]), 'Correctly identifies catagories'
+    assert list_unordered_equal(split.split_map, [[1], [2]]), 'Correctly identifies categories'
+    assert list_unordered_equal(split.split_groups, [[1], [2]]), 'Correctly generates split_groups property'
     assert list_unordered_equal(split.surrogates, []), 'No surrogates should be generated'
     assert split.p < 0.015
 
@@ -106,6 +107,8 @@ def test_spliting_identical_values():
         'Identifies correct column to split on'
     assert not split.valid(), \
         'Should not be able to split data with no skew'
+    assert split.groupings == '[]', 'Invalid split should return a string representing empty list as groupings property'
+    assert split.split_groups == [], 'Invalid split should return an empty list as split_groups property'
 
 
 def test_best_split_with_combination():
@@ -126,6 +129,7 @@ def test_best_split_with_combination():
     assert list_ordered_equal(arr, orig_arr), 'Calling chaid should have no side affects for original numpy arrays'
     assert split.column_id == 0, 'Identifies correct column to split on'
     assert list_unordered_equal(split.split_map, [[1], [2], [3]]), 'Correctly identifies categories'
+    assert list_unordered_equal(split.split_groups, [[1], [2], [3]]), 'Correctly generates split_groups property'
     assert list_unordered_equal(split.surrogates, []), 'No surrogates should be generated'
     assert split.p < 0.015
 
@@ -147,6 +151,7 @@ def test_best_split_with_combination_combining_if_too_small():
     assert list_ordered_equal(arr, orig_arr), 'Calling chaid should have no side affects for original numpy arrays'
     assert split.column_id == 0, 'Identifies correct column to split on'
     assert list_unordered_equal(split.split_map, [[1], [2, 3]]), 'Correctly identifies categories'
+    assert list_unordered_equal(split.split_groups, [[1], [2, 3]]), 'Correctly generates split_groups property'
     assert list_unordered_equal(split.surrogates, []), 'No surrogates should be generated'
     assert split.p < 0.055
 


### PR DESCRIPTION
I had a need to fit CHAID trees, and I had to update a few minor places in the code to get it to work with the latest packages (namely, `numpy`). This PR makes those updates and also pushes some of the package dependencies to be optional to reduce the size of the installation.

- Fixes errors due to numpy deprecation of `np.float` and `np.int`. Updated each to `np.float64` and `np.int64`.
- Added a new `split_groups` property in the `Split` class, which just returns the `groupings` as an actual list rather than the string representation of it.
- Split the required packages into two additional optional groups: `graph` (needed for generation of graphs, which isn't a core functionality needed to build the trees, per se) and `spss` (only needed for the initial import)
- Updated the CircleCI specs to the latest images, including newer Python versions (3.9, 3.10, 3.11)